### PR TITLE
Add logo URL

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -4,6 +4,7 @@
     "description": "A Pulumi component that synchronizes a local folder to Amazon S3, Azure Blob Storage, or Google Cloud Storage.",
     "homepage": "https://pulumi.com",
     "repository": "https://github.com/pulumi/pulumi-synced-folder",
+    "logoUrl": "https://raw.githubusercontent.com/pulumi/pulumi-synced-folder/master/assets/synced-folder.svg",
     "publisher": "Pulumi",
     "keywords": [
         "pulumi",


### PR DESCRIPTION
Adds `logoUrl` to the package schema to prevent `registrygen` from overwriting `logo_url` in Registry metadata with `""`.