### PR TITLE
Enable multiple SyncedFolder resources in programs

### DIFF
--- a/examples/synced-folder-aws-multiple-buckets/Pulumi.yaml
+++ b/examples/synced-folder-aws-multiple-buckets/Pulumi.yaml
@@ -1,0 +1,29 @@
+name: synced-folder-aws-yaml
+runtime: yaml
+
+resources:
+
+  my-bucket:
+    type: aws:s3:Bucket
+    properties:
+      acl: public-read
+
+  synced-folder:
+    type: synced-folder:index:S3BucketFolder
+    properties:
+      path: ./my-folder
+      bucketName: ${my-bucket.bucket}
+      acl: public-read
+
+  my-bucket-2:
+    type: aws:s3:Bucket
+    properties:
+      acl: public-read
+
+  synced-folder-2:
+    type: synced-folder:index:S3BucketFolder
+    properties:
+      path: ./my-folder
+      bucketName: ${my-bucket-2.bucket}
+      acl: public-read
+      disableManagedObjectAliases: true

--- a/examples/synced-folder-aws-multiple-buckets/my-folder/index.html
+++ b/examples/synced-folder-aws-multiple-buckets/my-folder/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Hello, world!</title>
+</head>
+<body>
+    Hi!
+</body>
+</html>

--- a/schema.json
+++ b/schema.json
@@ -33,6 +33,10 @@
                 "acl": {
                     "type": "string",
                     "description": "The AWS [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl) to apply to each file (e.g., `public-read`). Required."
+                },
+                "disableManagedObjectAliases": {
+                    "type": "boolean",
+                    "description": "Disables adding an [alias](https://www.pulumi.com/docs/intro/concepts/resources/options/aliases/) resource option to managed objects in the bucket."
                 }
             },
             "requiredInputs": [
@@ -69,6 +73,10 @@
                 "containerName": {
                     "type": "string",
                     "description": "The name of the Azure storage container to sync to. Required."
+                },
+                "disableManagedObjectAliases": {
+                    "type": "boolean",
+                    "description": "Disables adding an [alias](https://www.pulumi.com/docs/intro/concepts/resources/options/aliases/) resource option to managed objects in the bucket."
                 }
             },
             "requiredInputs": [
@@ -98,6 +106,10 @@
                 "bucketName": {
                     "type": "string",
                     "description": "The name of the Google Cloud Storage bucket to sync to (e.g., `my-bucket` in `gs://my-bucket`). Required."
+                },
+                "disableManagedObjectAliases": {
+                    "type": "boolean",
+                    "description": "Disables adding an [alias](https://www.pulumi.com/docs/intro/concepts/resources/options/aliases/) resource option to managed objects in the bucket."
                 }
             },
             "requiredInputs": [


### PR DESCRIPTION
Fixes a bug in registering child resources of the SyncedFolder component which manifests to users as an error. See:
- #10

Users may encounter an error like the following:

> error: Duplicate resource URN
> 'urn:pulumi:dev::synced-folder-aws-yaml::synced-folder:index:S3BucketFolder$aws:s3/bucketObject:BucketObject::index.html';
> try giving it a unique name

This error is caused by registering multiple child resources under the same name, in this case `index.html`. Fixing this by only changing the resource name however introduces a regression, users will would resource deletes and creates like so:

```
     pulumi:pulumi:Stack                    synced-folder-aws-yaml-dev
     └─ synced-folder:index:S3BucketFolder  synced-folder
 +      ├─ aws:s3:BucketObject              synced-folder-index.html    create
 -      └─ aws:s3:BucketObject              index.html                  delete
```

To fix this, we use the [aliases resource option](https://www.pulumi.com/docs/intro/concepts/resources/options/aliases/). This ensures the resource `synced-folder-index.html` is registered with an alias for the old name `index.html`, which allows Pulumi to rename the URN instead of planning a create and delete.

Users will encounter an error "Duplicate resource alias" if more than one resource is registered, so an input `disableManagedObjectAliases` is added to disabling the alias to the legacy name.
