### PR TITLE
Set `parent` for provider lookup within the component

### DIFF
--- a/provider/cmd/pulumi-resource-synced-folder/s3-bucket-folder.ts
+++ b/provider/cmd/pulumi-resource-synced-folder/s3-bucket-folder.ts
@@ -36,7 +36,7 @@ export class S3BucketFolder extends pulumi.ComponentResource {
         args.includeHiddenFiles = args.includeHiddenFiles ?? false;
 
         const folderContents = utils.getFolderContents(args.path, args.includeHiddenFiles);
-        const region = pulumi.output(aws.getRegion());
+        const region = pulumi.output(aws.getRegion(undefined, { parent: this }));
         const syncCommand = pulumi.interpolate`aws s3 sync "${args.path}" "s3://${args.bucketName}" --acl "${args.acl}" --region "${region.name}" --delete --only-show-errors`;
         const deleteCommand = pulumi.interpolate`aws s3 rm "s3://${args.bucketName}" --include "*" --recursive --only-show-errors`;
 


### PR DESCRIPTION
Fixes: #17 

When an explicit provider is passed to the component, the `aws.getRegion()` call fails at the moment. 

Correctly `parent`-ing it in the [invoke options](https://www.pulumi.com/docs/intro/concepts/resources/functions/#invoke-options) will do the provider lookup within the component first.
