### PR TITLE
[ci] use node 20.x for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,7 @@ jobs:
       fail-fast: true
       matrix:
         nodeversion:
-          - 18.x
+          - 20.x
   publish_sdk:
     name: Publish SDKs
     runs-on: ubuntu-latest


### PR DESCRIPTION
node 18.x LTS ended in April of this year

also, newer libraries are not compatible with node 18 

https://github.com/pulumi/pulumi-synced-folder/actions/runs/16923018175/job/47953158360