### PR TITLE
[ci] upgrade language versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -150,13 +150,13 @@ jobs:
         dotnetversion:
           - 3.1.301
         goversion:
-          - 1.20.x
+          - 1.23.x
         language:
           - nodejs
           - python
           - dotnet
           - go
         nodeversion:
-          - 18.x
+          - 20.x
         pythonversion:
-          - "3.9"
+          - "3.10"


### PR DESCRIPTION
It turns out that we maintain a list of versions for each language in the publish process (as well as in the source code for some languages like go). This PR updates node, python, and go since node 18 is not longer getting LTS, python 3.9 will be EOL in October of this year and our project / sdk now use go 1.23.