### PR TITLE
[ci] add back trusted publishing to pypi

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,6 @@ env:
   NPM_REGISTRY_URL: https://registry.npmjs.org
   NUGET_FEED_URL: https://api.nuget.org/v3/index.json
   PUBLISH_NUGET: true
-  PYPI_USERNAME: "pulumi"
   PYPI_REPOSITORY_URL: ""
   PUBLISH_PYPI: true
   NODE_OPTIONS: "--max-old-space-size=4096"
@@ -77,6 +76,8 @@ jobs:
     name: Publish SDKs
     runs-on: ubuntu-latest
     needs: publish_binary
+    permissions:
+      id-token: write
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
@@ -130,8 +131,6 @@ jobs:
         name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: ${{ env.PYPI_USERNAME }}
-          password: ${{ env.PYPI_PASSWORD }}
           packages_dir: ${{github.workspace}}/sdk/python/bin/dist
       - if: ${{ matrix.language == 'nodejs' && env.PUBLISH_NPM == 'true' }}
         uses: JS-DevTools/npm-publish@v1


### PR DESCRIPTION
> Error: As of 2024, PyPI requires all users to enable Two-Factor Authentication. This consequently requires all users to switch to either Trusted Publishers (preferred) or API tokens for package uploads. Read more: https://blog.pypi.org/posts/2023-05-25-securing-pypi-with-2fa/

We run with `attestations: true` but trusted publishing is disabled because we use basic auth for logging into pypi. This switches to using Trusted Publishers via pypi which is already configured on the pypi package.