### PR TITLE
[sdk] fix version substitution for python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,8 @@ build_python_sdk:: gen_python_sdk
 	cd sdk/python/ && \
 		rm -rf build dist ./*.egg-info && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^version = .*/version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		echo "Building Pythong SDK @ ${PYPI_VERSION}" && \
+		sed -i.bak -E "/^\[project\]/,/^\[[^]]+\]/{ s/^([[:space:]]*)version[[:space:]]*=.*/\1version = \"${PYPI_VERSION}\"/; }" ./bin/pyproject.toml && \
 		rm ./bin/pyproject.toml.bak && \
 		cd ./bin && python3 -m venv venv && ./venv/bin/pip install build && ./venv/bin/python3 -m build --sdist
 link:


### PR DESCRIPTION
```
$ sed -E   "/^\[project\]/,/^\[[^]]+\]/{ s/^([[:space:]]*)version[[:space:]]*=.*/\1version = \"${PYPI_VERSION}\"/; }"   ./bin/pyproject.toml
[project]
  name = "pulumi_synced_folder"
  description = "A Pulumi component that synchronizes a local folder to Amazon S3, Azure Blob Storage, or Google Cloud Storage."
  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
  keywords = ["pulumi", "aws", "azure", "gcp", "category/cloud", "kind/component"]
  readme = "README.md"
  requires-python = ">=3.9"
  version = "v0.12.4"
  [project.urls]
    Homepage = "https://pulumi.com"
    Repository = "https://github.com/pulumi/pulumi-synced-folder"

[build-system]
  requires = ["setuptools>=61.0"]
  build-backend = "setuptools.build_meta"

[tool]
  [tool.setuptools]
    [tool.setuptools.package-data]
      pulumi_synced_folder = ["py.typed", "pulumi-plugin.json"]
```